### PR TITLE
Start msyncd after unity8 not unity8-dash

### DIFF
--- a/debian/patches/0003-Added-upstart-service-file.patch
+++ b/debian/patches/0003-Added-upstart-service-file.patch
@@ -19,7 +19,7 @@ index 0000000..3ceced3
 +description "address-book-service"
 +author "Bill Filler <bill.filler@canonical.com>"
 +
-+start on started unity8-dash
++start on started unity8
 +stop on runlevel [06]
 +
 +# give some time to nm be ready


### PR DESCRIPTION
This fixes: https://github.com/ubports/ubuntu-touch/issues/1190