### PR TITLE
debian/control: add to B-D: libbluetooth-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,8 @@ Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 XSBC-Original-Maintainer: Duggirala Karthik <karthik.2.duggirala@nokia.com>
 Build-Depends: debhelper (>= 9),
                doxygen,
-               libaccounts-qt5-dev, 
+               libaccounts-qt5-dev,
+               libbluetooth-dev,
                libdbus-1-dev,
                libglib2.0-dev,
                libgsettings-qt-dev,


### PR DESCRIPTION
Sometime between Qt 5.9 and Qt 5.12, `libQt5SystemInfo` starts having `-lbluetooth` in its `.prl` file, which is then added to our `Makefile`. It means `libbluetooth-dev` is now our B-D.

Add this to our `debian/control`. I think `qtsystems5-dev` should have this as a dependency, but since we're in the freeze do this minimal change.